### PR TITLE
Only set keyboard layout for actual keyboards

### DIFF
--- a/roles/sway/templates/sway/config.j2
+++ b/roles/sway/templates/sway/config.j2
@@ -28,17 +28,19 @@ client.unfocused        {{ colors.background}}  {{ colors.background }} {{ color
 client.urgent           {{ colors.alert }}      {{ colors.background }} {{ colors.foreground }} {{ colors.alert }}    {{ colors.alert }}
 
 ### Behaviour
-
 exec swayidle -w \
     timeout 300 "$lock" \
     before-sleep "$lock"
 
-input "type:keyboard" {
+### Keyboard layout
+{% for keyboard_identifier in keyboard_identifiers %}
+input "{{ keyboard_identifier }}" {
     xkb_layout us
     xkb_model pc104
     xkb_variant altgr-intl
 }
 
+{% endfor %}
 ### Key bindings
 
 # Start a terminal

--- a/roles/sway/vars/main.yaml
+++ b/roles/sway/vars/main.yaml
@@ -1,5 +1,9 @@
 ---
 
+keyboard_identifiers:
+  - "6940:6968:Corsair_Corsair_Gaming_K70_RGB_RAPIDFIRE_Keyboard__Keyboard"
+  - "1:1:AT_Translated_Set_2_keyboard"
+
 # This theme is based on the Pywal base16-classic theme
 colors:
 


### PR DESCRIPTION
Firefox crashes on a sway reload if the input config matches multiple devices ([source](https://www.reddit.com/r/swaywm/comments/q1514z/can_i_avoid_crashing_firefox_on_sway_reload/)).